### PR TITLE
(fix) update jest-mock-promise-types.ts to use correct typing in param

### DIFF
--- a/dist/jest-mock-promise-types.d.ts
+++ b/dist/jest-mock-promise-types.d.ts
@@ -3,7 +3,7 @@ declare enum PromiseState {
     resolved = 1,
     rejected = 2,
 }
-declare type AnyFunction = (any) => any;
+declare type AnyFunction = (...args: any[]) => any;
 declare type HandlerType = {
     then?: AnyFunction;
     catch?: AnyFunction;

--- a/lib/jest-mock-promise-types.ts
+++ b/lib/jest-mock-promise-types.ts
@@ -4,7 +4,7 @@ enum PromiseState {
     rejected
  }
 
- type AnyFunction = (any)=>any;
+ type AnyFunction = (...args: any[])=>any;
 
  type HandlerType = {
      then?:AnyFunction,


### PR DESCRIPTION
Fixes #1 

Solution inspired from:

https://stackoverflow.com/questions/12697275/open-ended-function-arguments-with-typescript

https://github.com/Microsoft/TypeScript/issues/4338