### PR TITLE
Catch should call onRejected when PromiseState.rejected

### DIFF
--- a/lib/jest-mock-promise.ts
+++ b/lib/jest-mock-promise.ts
@@ -146,7 +146,7 @@ class JestMockPromise {
     public catch(onRejected:AnyFunction) {
         // if the promise is already rejected
         // > call the handler right away
-        if(this.state === PromiseState.resolved) {
+        if(this.state === PromiseState.rejected) {
             onRejected(this.err);
         } else {
             this.handlers.push({ catch: onRejected });


### PR DESCRIPTION
Probably a typo, but this was not working before this change:
```js
const promise = new JestMockPromise();
promise.reject(new Error("msg"));
promise.catch(err => console.log(err.message));
```

Expected behavior is that calling `catch` on a pre-rejected promise should immediately call the `onRejected` callback.